### PR TITLE
Fix Renovation discard issue

### DIFF
--- a/src/main/java/theHuman/cards/Renovation.java
+++ b/src/main/java/theHuman/cards/Renovation.java
@@ -50,7 +50,7 @@ public class Renovation extends AbstractDynamicCard {
         int size = p.hand.size();
         this.addToBot(new DiscardAction(p, p, size, true));
         this.addToBot(new DrawCardAction(magicNumber));
-        size = p.hand.size();
+        size = MAGIC_NUMBER;
         this.addToBot(new DiscardAction(p, p, size, true));
         this.addToBot(new DrawCardAction(defaultSecondMagicNumber));
     }


### PR DESCRIPTION
I've been experiencing a bug with the Renovation card. It discards my hand, draws up to 10, then fails to discard my entire hand, leaving me with >5 cards at the end after drawing 5.

My best guess as to a cause is that the `p.hand.size` is not properly updated after the first round of discarding and drawing. My second best guess is that there's an async timing issue.

Given that the player has just drawn 10 cards, and so they should have 10 cards in hand, I've suggested a change in `size` from `p.hand.size` to 10 (or `MAGIC_NUMBER` which in this case is 10. Not sure yet what `MAGIC_NUMBER` indicates as a naming convention). 

This should make the card function as written on its face under most circumstances. That said, a `size` of 10 will not be accurate in the case that the player was able to obtain and play Battle Trance beforehand. I wonder if there's a way to force StS to reevaluate the hand size. 

If attempting to discard more cards than the player has in hand is easy for StS to handle, I believe this PR will be helpful. If not, it's your judgement call on whether you'd like to have the card work right and cause a crash under extreme circumstances or whether you'd rather change the way the card works. Or you could come up with a different fix I haven't thought of.

At any rate, thanks for putting out this super fun mod.